### PR TITLE
Add Label Descriptions issue #84

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -30,7 +30,11 @@ module.exports = function copy (request, reply, decoded) {
       gh({
         method: 'POST',
         path: labelsPath(repoData.targetOwner, repoData.targetRepo),
-        body: { name: label.name, color: label.color }
+        body: {
+          name: label.name,
+          color: label.color,
+          description: label.description || '' // empty string when description is null
+        }
       }, function (error, data) {
         hoek.assert(!error, error);
         labelsSet += 1;
@@ -49,7 +53,7 @@ module.exports = function copy (request, reply, decoded) {
         } else if (labelsSet === labels.length
           && data.message === 'Validation Failed') {
           return reply.view('sync-fail', { error: 'Labels already synced' })
-          .state('last', repoData);
+            .state('last', repoData);
         }
 
         return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labels",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request adds the code to sync label descriptions as described in #84 :shipit: 
Unfortunately, a couple of the tests fail as noted in #92 😞  (_due to a breaking change in dependency_...)

The only way we can _fix_ the failing tests is to _manually_ debug each one ... ⏳ 
https://travis-ci.org/github/dwyl/labels/builds/713637356#L552

The application works flawlessly on my `localhost`:
<img width="693" alt="label-sync-success-localhost" src="https://user-images.githubusercontent.com/194400/89026718-17820580-d321-11ea-9c27-07f4f7ae81d5.png">

https://github.com/nelsonic/learn-music/labels

***Before***:
![nelsonic-learn-music-before-sync](https://user-images.githubusercontent.com/194400/89026754-28327b80-d321-11ea-92e2-2681a4777ad3.png)

***After***:
![nelsonic-learn-music-after-sync-with-label-descriptions](https://user-images.githubusercontent.com/194400/89026784-3385a700-d321-11ea-8f38-80e3042d9c50.png)
