### PR TITLE
Add Node version 4.1.1 to package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "hoek": "^4.1.0",
     "jsonwebtoken": "^7.1.9",
     "vision": "^4.1.0"
+  },
+  "engines": {
+    "node": "4.1.1"
   }
 }


### PR DESCRIPTION
As discussed in: https://github.com/dwyl/labels/issues/95#issuecomment-667486411
I've added a couple of lines to `package.json` to keep Heroku happy (_for now_...)



