### PR TITLE
Migrate fly to v2

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,10 +1,15 @@
-# fly.toml file generated for labels on 2022-03-01T13:12:41Z
+# fly.toml app configuration file generated for labels on 2023-06-12T16:07:23+01:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
 app = "labels"
-
+primary_region = "lhr"
 kill_signal = "SIGTERM"
-kill_timeout = 5
-processes = []
+kill_timeout = "5s"
+
+[experimental]
+  auto_rollback = true
 
 [deploy]
   release_command = "/app/bin/migrate"
@@ -13,32 +18,25 @@ processes = []
   PHX_HOST = "labels.fly.dev"
   PORT = "8080"
 
-[experimental]
-  allowed_public_ports = []
-  auto_rollback = true
-
 [[services]]
-  http_checks = []
+  protocol = "tcp"
   internal_port = 8080
   processes = ["app"]
-  protocol = "tcp"
-  script_checks = []
 
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
   [services.concurrency]
+    type = "connections"
     hard_limit = 25
     soft_limit = 20
-    type = "connections"
-
-  [[services.ports]]
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
 
   [[services.tcp_checks]]
-    grace_period = "1s"
     interval = "15s"
-    restart_limit = 0
     timeout = "2s"
+    grace_period = "1s"
+    restart_limit = 0


### PR DESCRIPTION
Run `fly migrate-to-v2 -c ./fly.toml` to
migrate the application to v2

see #209 